### PR TITLE
Added config value for accounts server

### DIFF
--- a/config/zoho-desk.php
+++ b/config/zoho-desk.php
@@ -11,4 +11,5 @@ return [
     'access_type' => env('ZOHO_DESK_ACCESS_TYPE', 'offline'),
     'organisation_id' => env('ZOHO_DESK_ORGANISATION_ID'),
     'base_url' => env('ZOHO_DESK_BASE_URL', 'https://desk.zoho.com.au'),
+    'accounts_server' => env('ZOHO_DESK_ACCOUNTS_SERVER', 'https://accounts.zoho.com.au'),
 ];

--- a/src/OAuth/ZohoProvider.php
+++ b/src/OAuth/ZohoProvider.php
@@ -14,7 +14,7 @@ class ZohoProvider extends AbstractProvider
 
     public function accountsServer()
     {
-        return 'https://accounts.zoho.com.au';
+        return config('zoho-desk.accounts_server');
     }
 
     public function hostResourceLocation()


### PR DESCRIPTION
If your Zoho account is registered in another data center you will not able to grant access for your application.
This changes should fix the problem.